### PR TITLE
Improve architecture detection

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,14 +4,25 @@
 # COMMON VARIABLES
 #=================================================
 
-architecture=$(dpkg --print-architecture)
-if [ $architecture = "amd64" ]; then
-  architecture="x64"
-fi
+# Supported architectures
+supported_architectures=("arm" "arm64" "x64")
 
 #=================================================
 # PERSONAL HELPERS
 #=================================================
+
+get_architecture() {
+        architecture=$(dpkg --print-architecture)
+        if [ $architecture = "amd64" ]; then
+                architecture="x64"
+        elif [[ $architecture = arm* ]] && [[ $(getconf LONG_BIT) = 32 ]]; then
+                architecture="arm"
+        elif [[ $architecture = arm* ]] && [[ $(getconf LONG_BIT) = 64 ]]; then
+                architecture="arm64"
+        elif [[ $(echo ${supported_architectures[@]} | grep -ow "$architecture" | wc -w) = 0 ]]; then
+                ynh_die --message="Unsupported architecture $architecture"
+        fi
+}
 
 #=================================================
 # EXPERIMENTAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -68,7 +68,9 @@ ynh_system_user_create --username=$app --home_dir="$final_path"
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
-ynh_script_progression --message="Setting up source files..." 
+ynh_script_progression --message="Setting up source files..."
+
+get_architecture
 
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 # Download, check integrity, uncompress and patch the source from app.src

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,10 +112,12 @@ ynh_system_user_create --username=$app --home_dir="$final_path"
 
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
-	ynh_script_progression --message="Upgrading source files..." 
+	ynh_script_progression --message="Upgrading source files..."
+
+	get_architecture
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$final_path"
+	ynh_setup_source --dest_dir="$final_path" --source_id="app.$architecture"
 fi
 
 # FIXME: this should be managed by the core in the future


### PR DESCRIPTION
## Problem

- On my RPi4 the app was trying to install the  `armhf` source (missing).

## Solution

- Use a small helper I wrote to differenciate between all the `arm` flavours and select `arm32`/`arm64` sources.
- Return an error if the architectures do not match the supported ones.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
