### PR TITLE
Upgrade to v0.22.1445

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Shipped version:** 0.22.1425~ynh1
+**Shipped version:** 0.22.1445~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Versión actual:** 0.22.1425~ynh1
+**Versión actual:** 0.22.1445~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Paketatutako bertsioa:** 0.22.1425~ynh1
+**Paketatutako bertsioa:** 0.22.1445~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 Jackett fonctionne comme un serveur proxy : il traduit les requêtes des applications (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious, etc.) en requêtes http spécifiques au site de suivi, analyse la réponse HTML ou JSON, puis renvoie les résultats au logiciel demandeur. Cela permet d'obtenir des téléchargements récents (comme RSS) et d'effectuer des recherches. Jackett est un référentiel unique de logique de scraping et de traduction d'indexeurs maintenue, ce qui supprime la charge des autres applications.
 
-**Version incluse :** 0.22.1425~ynh1
+**Version incluse :** 0.22.1445~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Versión proporcionada:** 0.22.1425~ynh1
+**Versión proporcionada:** 0.22.1445~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Versi terkirim:** 0.22.1425~ynh1
+**Versi terkirim:** 0.22.1445~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Geleverde versie:** 0.22.1425~ynh1
+**Geleverde versie:** 0.22.1445~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Dostarczona wersja:** 0.22.1425~ynh1
+**Dostarczona wersja:** 0.22.1445~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**Поставляемая версия:** 0.22.1425~ynh1
+**Поставляемая версия:** 0.22.1445~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches. Jackett is a single repository of maintained indexer scraping & translation logic - removing the burden from other apps.
 
 
-**分发版本：** 0.22.1425~ynh1
+**分发版本：** 0.22.1445~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jackett"
 description.en = "API support for your favorite torrent trackers"
 description.fr = "API pour vos trackers torrent préférés"
 
-version = "0.22.1425~ynh1"
+version = "0.22.1445~ynh1"
 
 maintainers = ["Navan Chauhan"]
 
@@ -39,12 +39,12 @@ ram.runtime = "200M"
 
 [resources]
     [resources.sources.main]
-    amd64.url = "https://github.com/Jackett/Jackett/releases/download/v0.22.1425/Jackett.Binaries.LinuxAMDx64.tar.gz"
-    amd64.sha256 = "7041d34716600ff82d2e18e9194ca233c360fc0bf59c1a1a0158d5c3b32d8120"
-    arm64.url = "https://github.com/Jackett/Jackett/releases/download/v0.22.1425/Jackett.Binaries.LinuxARM64.tar.gz"
-    arm64.sha256 = "fb63dd3a733128ce7a85dd73f24bdb1c7ee064402ba3a60c695003b97a2d1e2d"
-    armhf.url = "https://github.com/Jackett/Jackett/releases/download/v0.22.1425/Jackett.Binaries.LinuxARM32.tar.gz"
-    armhf.sha256 = "1988fd07582c2441b0f9055ad9cf2bb40f9020fca04f42a4910f36e97028ff90"
+    amd64.url = "https://github.com/Jackett/Jackett/releases/download/v0.22.1445/Jackett.Binaries.LinuxAMDx64.tar.gz"
+    amd64.sha256 = "11889af24ae599b5490dec14f678d57d0adf186b9fb6ed4b8db00bdb4347028b"
+    arm64.url = "https://github.com/Jackett/Jackett/releases/download/v0.22.1445/Jackett.Binaries.LinuxARM64.tar.gz"
+    arm64.sha256 = "31fd1f0699653117f61548b7f407c48c668dffba3630f3905eced61cc31ce2e2"
+    armhf.url = "https://github.com/Jackett/Jackett/releases/download/v0.22.1445/Jackett.Binaries.LinuxARM32.tar.gz"
+    armhf.sha256 = "d8b76cfc9132ff1bc29802ebd4de65bb2e08975b6477fcd84cd51d8eb3df987e"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.amd64 = "^Jackett.Binaries.LinuxAMDx64.tar.gz$"

--- a/tests.toml
+++ b/tests.toml
@@ -8,7 +8,17 @@ test_format = 1.0
     # Tests to run
     # ------------
 
+    # -------------------------------
+    # Default args to use for install
+    # -------------------------------
+
     [default.curl_tests]
     # ugly hack to make tests enable cookies,
     # otherwise UI says 'Enable cookies' and fails
     default.logged_on_sso = true
+
+    # -------------------------------
+    # Commits to test upgrade from
+    # -------------------------------
+
+    # test_upgrade_from.dbcf6acc1bcdb4bd3b2d8e57a48f5e1c7594d8c7.name = "Upgrade from 0.22.1425~ynh1"


### PR DESCRIPTION
Upgrade sources
- `main` v0.22.1445: https://github.com/Jackett/Jackett/releases/tag/v0.22.1445

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
